### PR TITLE
Security: Add .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+.env export-ignore
+.env.local export-ignore
+tests/ export-ignore


### PR DESCRIPTION
Prevents sensitive files and test suites from being included in git archive exports.