### PR TITLE
🛡️ Sentinel: add security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,20 @@
+# Security Policy
+
+## Supported Versions
+
+Currently, the latest version of the repository is supported for security updates.
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 1.0.x   | :white_check_mark: |
+| < 1.0   | :x:                |
+
+## Reporting a Vulnerability
+
+The project maintainers are committed to the security of this repository. If you discover a security vulnerability, please follow these steps:
+
+1.  **Do not** open a public issue.
+2.  Use GitHub's [Private Vulnerability Reporting](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-reporting-vulnerabilities/privately-reporting-a-security-vulnerability) feature if available on this repository.
+3.  Alternatively, you can contact the project lead, **Turbo** (@Turbo-the-tech-dev), through their GitHub profile to arrange a secure disclosure method.
+
+We will acknowledge your report within 48 hours and provide a timeline for a fix if the vulnerability is confirmed. Thank you for helping keep this project secure!


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Missing security policy for vulnerability reporting.
🎯 Impact: Security researchers might disclose vulnerabilities publicly if no private channel is defined.
🔧 Fix: Added SECURITY.md outlining the process for private reporting.
✅ Verification: Ran ./audit.sh and verified that the missing SECURITY.md check now passes.

---
*PR created automatically by Jules for task [14135911160652469234](https://jules.google.com/task/14135911160652469234) started by @Turbo-the-tech-dev*