### PR TITLE
🛡️ Sentinel: [CRITICAL/HIGH] Fix command injection in speak.sh

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-03-10 - Shell Command Injection in Lore Aggregator
+**Vulnerability:** Command injection and command chaining in `speak.sh` via the `GEMINI_BRAINROT.md` file.
+**Learning:** Even when variables are wrapped in double quotes in a shell script, they are still vulnerable to command substitution (`$(...)` or `` `...` ``) and command chaining if not properly validated.
+**Prevention:** Implement a strict validation gate using regex (`grep -qE '[\`$;&|\\"]'`) for any variable derived from external files before it is used in a shell command. Use `printf` instead of `echo` for safer handling of variable content.

--- a/speak.sh
+++ b/speak.sh
@@ -5,14 +5,28 @@
 
 TARGET_MD="GEMINI_BRAINROT.md"
 
-echo ">> [SYSTEM] Extracting latest neural thought..."
+printf ">> [SYSTEM] Extracting latest neural thought...\n"
 
 # Grab the last line, strip out the timestamps and formatting for clean audio
 LAST_THOUGHT=$(tail -n 1 "$TARGET_MD" | sed -e 's/.* - //')
 
-echo ">> [SPEAKING] \"$LAST_THOUGHT\""
+# SECURITY GATE: Reject thoughts containing shell metacharacters to prevent command injection.
+# We block characters that allow command substitution, chaining, or quoting manipulation.
+if printf "%s" "$LAST_THOUGHT" | grep -qE '[`$;&|\\"]'; then
+    printf ">> [ERROR] Malicious neural thought detected. Execution halted.\n"
+    exit 1
+fi
+
+# DEPENDENCY CHECK: Ensure TTS engine is available
+if ! command -v termux-tts-speak >/dev/null 2>&1; then
+    printf ">> [WARNING] termux-tts-speak not found. Simulation mode active.\n"
+    printf ">> [SPEAKING] \"%s\"\n" "$LAST_THOUGHT"
+    exit 0
+fi
+
+printf ">> [SPEAKING] \"%s\"\n" "$LAST_THOUGHT"
 
 # Pipe to Termux TTS
 termux-tts-speak "Sigma Protocol Update: $LAST_THOUGHT"
 
-echo ">> [SUCCESS] Vocalization complete."
+printf ">> [SUCCESS] Vocalization complete.\n"


### PR DESCRIPTION
### 🚨 Severity
HIGH

### 💡 Vulnerability
The `speak.sh` script was vulnerable to command injection and command chaining. It read the last line of `GEMINI_BRAINROT.md` and interpolated it directly into a shell command within double quotes. While double quotes prevent some types of expansion, they still allow for command substitution (`$(...)` or backticks) and can be bypassed with quotes to chain commands.

### 🎯 Impact
An attacker who can modify `GEMINI_BRAINROT.md` (e.g., through a PR or another vulnerability) could execute arbitrary shell commands on the system running the script.

### 🔧 Fix
- Implemented a **Security Gate** using `grep -qE '[\`$;&|\\"]'` to reject any input containing shell metacharacters.
- Switched from `echo` to `printf` for safer output handling.
- Added a dependency check for `termux-tts-speak` with a graceful fallback to simulation mode.

### ✅ Verification
Tested the script with:
- Safe text: Accepted and processed.
- Command substitution (`$(echo injected)`): Rejected.
- Command chaining (`; echo injected`): Rejected.
- Quote manipulation (`" ; echo injected`): Rejected.
- Verified that simulation mode works when `termux-tts-speak` is missing.

---
*PR created automatically by Jules for task [7657826661449279627](https://jules.google.com/task/7657826661449279627) started by @Turbo-the-tech-dev*