### PR TITLE
🛡️ Sentinel: [security improvement] Harden speak.sh against command injection

### DIFF
--- a/speak.sh
+++ b/speak.sh
@@ -5,14 +5,26 @@
 
 TARGET_MD="GEMINI_BRAINROT.md"
 
-echo ">> [SYSTEM] Extracting latest neural thought..."
+printf ">> [SYSTEM] Extracting latest neural thought...\n"
 
 # Grab the last line, strip out the timestamps and formatting for clean audio
+# We use a temp variable to check for injection risks before speaking
 LAST_THOUGHT=$(tail -n 1 "$TARGET_MD" | sed -e 's/.* - //')
 
-echo ">> [SPEAKING] \"$LAST_THOUGHT\""
+# SECURITY GATE: Reject input with shell metacharacters to prevent injection
+if printf "%s" "$LAST_THOUGHT" | grep -qE '[`$;&|\\"]'; then
+    printf ">> [SECURITY] Critical: Malicious neural thought detected. Execution halted.\n"
+    exit 1
+fi
 
-# Pipe to Termux TTS
-termux-tts-speak "Sigma Protocol Update: $LAST_THOUGHT"
+printf ">> [SPEAKING] \"%s\"\n" "$LAST_THOUGHT"
 
-echo ">> [SUCCESS] Vocalization complete."
+# SAFE EXECUTION: Verify TTS engine exists before calling
+if command -v termux-tts-speak >/dev/null 2>&1; then
+    # Double quote variable to prevent word splitting, though validation gate
+    # already handles the most dangerous characters.
+    termux-tts-speak "Sigma Protocol Update: $LAST_THOUGHT"
+    printf ">> [SUCCESS] Vocalization complete.\n"
+else
+    printf ">> [OFFLINE] TTS Engine (termux-tts-speak) not found. Text-only fallback active.\n"
+fi


### PR DESCRIPTION
💡 **Security Improvement**: Hardened `speak.sh` against potential command injection and improved robustness.

🎯 **Why**: The script extracts "machine thoughts" from an external file (`GEMINI_BRAINROT.md`) and passes them as arguments to the `termux-tts-speak` command. While variables are quoted, adding an explicit validation gate provides defense-in-depth against subshell expansion (`$(...)`) or breakout attempts if the script or input sources are modified.

🔧 **Fix**: 
- **Validation Gate**: Implemented `grep -qE '[\`$;&|\\"]'` to reject any input containing dangerous shell metacharacters.
- **Engine Check**: Added a `command -v termux-tts-speak` check to verify the presence of the TTS engine before execution, providing a clear fallback message if it is missing.
- **Safe Output**: Refactored `echo` calls to `printf` to ensure variables are handled as literal data and not interpreted as shell flags or escape sequences.
- **Defensive Design**: Added graceful handling for security rejections and environment limitations.

✅ **Verification**: 
- **Benign Test**: Verified that standard text is still processed and "spoken" (via fallback) correctly.
- **Adversarial Test**: Confirmed that inputs containing `; touch VULNERABLE`, `$(id)`, and backticks are successfully blocked by the security gate.
- **Regression**: Ran `./audit.sh` to ensure general repository health.

---
*PR created automatically by Jules for task [16068610340324862808](https://jules.google.com/task/16068610340324862808) started by @Turbo-the-tech-dev*