### PR TITLE
🛡️ Sentinel: [security improvement] Harden speak.sh against command injection

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-04-12 - Command Injection in TTS Script
+**Vulnerability:** The `speak.sh` script read the last line of `GEMINI_BRAINROT.md` and passed it directly to a shell command (`termux-tts-speak`) inside double quotes. This allowed arbitrary command execution if the input contained shell metacharacters like `$()` or `` ` ``.
+**Learning:** Even when variables are double-quoted, they are still subject to command substitution and variable expansion. Input from external files must be strictly validated before being used in shell commands.
+**Prevention:** Implement a validation gate using `grep` to reject shell metacharacters (`\`, `` ` ``, `$`, `;`, `&`, `|`, `"`) from untrusted input. Use `printf` instead of `echo` for safer output handling.

--- a/speak.sh
+++ b/speak.sh
@@ -1,18 +1,36 @@
 #!/bin/bash
+set -euo pipefail
 # ==============================================================================
 # IMPERIAL COMMAND: TTS LORE AGGREGATOR
 # ==============================================================================
 
 TARGET_MD="GEMINI_BRAINROT.md"
 
-echo ">> [SYSTEM] Extracting latest neural thought..."
+printf ">> [SYSTEM] Extracting latest neural thought...\n"
 
 # Grab the last line, strip out the timestamps and formatting for clean audio
+# Defensive check: ensure the file exists
+if [[ ! -f "$TARGET_MD" ]]; then
+    printf ">> [ERROR] %s not found.\n" "$TARGET_MD" >&2
+    exit 1
+fi
+
 LAST_THOUGHT=$(tail -n 1 "$TARGET_MD" | sed -e 's/.* - //')
 
-echo ">> [SPEAKING] \"$LAST_THOUGHT\""
+# Validation gate: Reject shell metacharacters to prevent command injection
+# via $() or `` when the variable is expanded in double quotes.
+if printf "%s" "$LAST_THOUGHT" | grep -qE '[\\`$;&|"]'; then
+    printf ">> [ERROR] Malicious input detected in %s. Neural load rejected.\n" "$TARGET_MD" >&2
+    exit 1
+fi
 
-# Pipe to Termux TTS
-termux-tts-speak "Sigma Protocol Update: $LAST_THOUGHT"
+printf ">> [SPEAKING] \"%s\"\n" "$LAST_THOUGHT"
 
-echo ">> [SUCCESS] Vocalization complete."
+# Pipe to Termux TTS if available
+if command -v termux-tts-speak >/dev/null 2>&1; then
+    termux-tts-speak "Sigma Protocol Update: $LAST_THOUGHT"
+else
+    printf ">> [SIMULATION] termux-tts-speak not found. Audio: \"Sigma Protocol Update: %s\"\n" "$LAST_THOUGHT"
+fi
+
+printf ">> [SUCCESS] Vocalization complete.\n"


### PR DESCRIPTION
🚨 **Severity**: MEDIUM/HIGH (Security Improvement)

💡 **Vulnerability**: Potential Command Injection in `speak.sh`. The script was reading the last line of an external file (`GEMINI_BRAINROT.md`) and expanding it directly within a shell command inside double quotes, allowing for command substitution (e.g., `$(...)` or `` `...` ``).

🎯 **Impact**: If an attacker or automated process could inject shell metacharacters into `GEMINI_BRAINROT.md`, they could execute arbitrary commands with the privileges of the user running `speak.sh` or `make speak`.

🔧 **Fix**:
- **Validation Gate**: Added a regex check using `grep` to proactively reject any input containing shell metacharacters (`\`, `` ` ``, `$`, `;`, `&`, `|`, `"`).
- **Robustness**: Enabled `set -euo pipefail` to ensure the script fails fast on errors or unset variables.
- **Defensive Checks**: Added checks for the existence of the source file and the `termux-tts-speak` command to fail gracefully.
- **Safer Output**: Replaced `echo` with `printf` for handling variable content to prevent misinterpretation of flags.
- **Documentation**: Logged the vulnerability pattern and prevention strategy in the security journal at `.jules/sentinel.md`.

✅ **Verification**: 
- Verified that clean input still processes correctly (in simulation mode since `termux-tts-speak` is absent in this env).
- Verified that malicious inputs like `$(echo INJECTED)` or `Normal; rm -rf /` are now detected and correctly blocked.
- Ran `./audit.sh` to ensure no repository-wide regressions.

---
*PR created automatically by Jules for task [6978404048209708428](https://jules.google.com/task/6978404048209708428) started by @Turbo-the-tech-dev*